### PR TITLE
Fixed chart persistence bug by implementing graph instance isolation

### DIFF
--- a/client.py
+++ b/client.py
@@ -2,37 +2,68 @@ import streamlit as st
 import requests
 import json
 import pandas as pd
+import altair as alt
+import time
 
 def process_tool_data(tool_data):
     if not tool_data:
         return None
     try:
-        # Parse the JSON string into a Python object
         data = json.loads(tool_data)
-        
-        # Debug print to see the data structure
-        print("Parsed tool data:", data)
-        
-        # Convert to DataFrame
         df = pd.DataFrame(data)
         
-        # Check if DataFrame has the required columns
         required_columns = ['strongBuy', 'buy', 'hold', 'sell', 'strongSell', 'period']
         if not all(col in df.columns for col in required_columns):
             print(f"Missing columns. Available columns: {df.columns.tolist()}")
             return None
             
-        # Format period column
         df['period'] = pd.to_datetime(df['period']).dt.strftime('%Y-%m')
-        df.set_index('period', inplace=True)
         
-        print("Processed DataFrame:", df)
-        return df
+        df_melted = df.melt(
+            id_vars=['period'],
+            value_vars=['strongBuy', 'buy', 'hold', 'sell', 'strongSell'],
+            var_name='Recommendation',
+            value_name='Count'
+        )
         
-    except (json.JSONDecodeError, KeyError, IndexError, AttributeError) as e:
+        return df_melted
+        
+    except Exception as e:
         print(f"Error processing tool data: {e}")
-        print(f"Tool data received: {tool_data}")
         return None
+
+def create_altair_chart(df):
+    if df is None or df.empty:
+        return None
+        
+    chart = alt.Chart(df).mark_bar().encode(
+        x=alt.X('period:N', title='Period'),
+        y=alt.Y('Count:Q', title='Number of Recommendations'),
+        color=alt.Color('Recommendation:N', 
+            scale=alt.Scale(
+                domain=['strongBuy', 'buy', 'hold', 'sell', 'strongSell'],
+                range=['#1a9850', '#91cf60', '#ffffbf', '#fc8d59', '#d73027']
+            )
+        ),
+        tooltip=['period', 'Recommendation', 'Count']
+    ).properties(
+        width=600,
+        height=400,
+        title='Analyst Recommendations'
+    )
+    
+    return chart
+
+def reset_server_state():
+    """Reset the server state completely"""
+    try:
+        reset_response = requests.post(f"{URL}/reset")
+        if reset_response.status_code == 200:
+            print("Server state reset successfully")
+        else:
+            print(f"Failed to reset server state: {reset_response.status_code}")
+    except Exception as e:
+        print(f"Error resetting server state: {e}")
 
 # Set page config to change the title on the navbar
 st.set_page_config(page_title="Stonks Chat 📈")
@@ -59,71 +90,108 @@ st.markdown(
     unsafe_allow_html=True
 )
 
+# Initialize session state for conversation
+if "conversation" not in st.session_state:
+    st.session_state.conversation = []
+    st.session_state.message_counter = 0
+    st.session_state.current_chart_id = None  # Track which message has a chart
 
-# Initialize chat history
-if "messages" not in st.session_state:
-    st.session_state.messages = []
+# Function to render all messages including charts
+def render_conversation():
+    for message in st.session_state.conversation:
+        with st.chat_message(message["role"]):
+            # Always render the content
+            st.markdown(message["content"])
+            
+            # Handle chart rendering - only for the current active chart
+            if message.get("chart_data") and message.get("id") == st.session_state.current_chart_id:
+                df = process_tool_data(message["chart_data"])
+                if df is not None and not df.empty:
+                    chart = create_altair_chart(df)
+                    if chart:
+                        # Generate a unique key for this chart
+                        chart_key = f"chart_{message.get('id', 'default')}"
+                        st.altair_chart(chart, use_container_width=True, key=chart_key)
 
-# Display chat messages from history on app rerun
-for message in st.session_state.messages:
-    with st.chat_message(message["role"]):
-        st.markdown(message["content"])
+# Render existing conversation
+render_conversation()
 
 # Accept user input
 if prompt := st.chat_input("Type a message..."):
-    # Add user message to chat history
-    st.session_state.messages.append({"role": "user", "content": prompt})
-    # Display user message in chat message container
+    # IMPORTANT: Reset chart state completely for ALL messages when new prompt received
+    for message in st.session_state.conversation:
+        if "chart_data" in message:
+            message["chart_data"] = None
+    
+    # Create a new user message
+    user_message = {
+        "role": "user",
+        "content": prompt,
+        "id": f"user_{st.session_state.message_counter}"
+    }
+    st.session_state.message_counter += 1
+    
+    # Add to conversation and display
+    st.session_state.conversation.append(user_message)
     with st.chat_message("user"):
         st.markdown(prompt)
     
-    # Send prompt to server and get response
+    # Create API request
     data = {'prompt': prompt}
     headers = {'Content-Type': 'application/json'}
-    response = requests.post(URL, data=json.dumps(data), headers=headers)
     
-    if response.status_code == 200:
-        with st.chat_message("assistant"):
-            full_response = ""
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:
-                    full_response += chunk.decode('utf-8')
-            
+    # Process response with a placeholder
+    with st.chat_message("assistant"):
+        message_placeholder = st.empty()
+        message_placeholder.markdown("Thinking...")
+        
+        # Get response from server
+        response = requests.post(URL, data=json.dumps(data), headers=headers)
+        
+        if response.status_code == 200:
             try:
-                parsed_response = json.loads(full_response)
+                # Parse response data
+                parsed_response = json.loads(response.content)
                 message_content = parsed_response.get("message", "")
                 tool_data = parsed_response.get("tool_data")
+                tool_type = parsed_response.get("tool_type")
+                message_id = parsed_response.get("message_id") or f"assistant_{st.session_state.message_counter}"
                 
-                # Check if tool_data contains news data by attempting to parse it
-                if tool_data:
-                    try:
-                        data = json.loads(tool_data)
-                        # If the data has 'summaries' key, it's from getCompanyNews
-                        if 'summaries' in data:
-                            # Only display the markdown formatted message from LLM
-                            st.markdown(message_content)
-                        else:
-                            # For other tools like stock recommendations, process and show charts
-                            df = process_tool_data(tool_data)
-                            if df is not None and not df.empty:
-                                st.bar_chart(df[['strongBuy', 'buy', 'hold', 'sell', 'strongSell']])
-                            st.markdown(message_content)
-                    except json.JSONDecodeError:
-                        # If tool_data isn't valid JSON, just show the message
-                        st.markdown(message_content)
-                else:
-                    # If no tool_data, just show the message
-                    st.markdown(message_content)
+                # Update placeholder with response text
+                message_placeholder.markdown(message_content)
                 
-                # Add assistant response to chat history
-                st.session_state.messages.append({
-                    "role": "assistant", 
-                    "content": message_content
-                })
+                # Create assistant message with proper ID
+                assistant_message = {
+                    "role": "assistant",
+                    "content": message_content,
+                    "id": message_id,
+                    "chart_data": None  # Will be set only if chart data exists
+                }
+                st.session_state.message_counter += 1
+                
+                # Handle chart data if present
+                chart_container = st.container()
+                if tool_data and tool_type == "chart":
+                    # Store chart data in message
+                    assistant_message["chart_data"] = tool_data
+                    st.session_state.current_chart_id = message_id
+                    
+                    # Display chart for current response
+                    with chart_container:
+                        df = process_tool_data(tool_data)
+                        if df is not None and not df.empty:
+                            chart = create_altair_chart(df)
+                            if chart:
+                                # Use message ID as part of chart key
+                                st.altair_chart(chart, use_container_width=True, key=f"new_chart_{message_id}")
+                
+                # Add message to conversation
+                st.session_state.conversation.append(assistant_message)
+                
             except json.JSONDecodeError:
-                st.error("Failed to parse server response as JSON.")
-    else:
-        st.error("Failed to get response from server.")
+                message_placeholder.error("Failed to parse server response as JSON.")
+        else:
+            message_placeholder.error(f"Error from server: {response.status_code}")
         
 # Footer for streamlit chat UI
 footer = st._bottom.empty()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ langchain
 langchain_openai
 langgraph
 finnhub-python
+altair

--- a/server.py
+++ b/server.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from llm import graph
+from llm import create_graph  # Import create_graph instead of graph
 from langchain_core.messages import HumanMessage, ToolMessage
+import uuid
 
 app = FastAPI()
 
@@ -9,32 +10,61 @@ app = FastAPI()
 class PromptReq(BaseModel):
     prompt: str
 
+# Store graph instances - create a new instance for each thread
+graph_instances = {}
+
 @app.get("/")
 async def get():
     return {"message": "Hello, World!"}
 
+@app.post("/reset")
+async def reset_state():
+    """Reset the graph state completely"""
+    global graph_instances
+    graph_instances = {}  # Clear all graph instances
+    return {"status": "All graph states reset successfully"}
+
 @app.post("/")
 async def chat(request: PromptReq):
-    config = {"configurable": {"thread_id": "abc123"}}
+    # Create a unique thread ID for each request
+    thread_id = f"thread-{uuid.uuid4()}"
+    config = {"configurable": {"thread_id": thread_id}}
+    
+    # Create a fresh graph for this request
+    graph = create_graph()
+    graph_instances[thread_id] = graph
+    
+    # Reset chart data and message ID for new request
     messages = {"messages": [HumanMessage(request.prompt)]}
-    graph.update_state(config, {"language": "English"})
-
+    
+    # Get response from graph
     output = graph.invoke(messages, config)
     
     # Find the ToolMessage in the messages list
     tool_message = None
+    tool_type = None
+    message_id = None
+    
     for msg in output["messages"]:
         if isinstance(msg, ToolMessage):
-            # Check if this is a news API call by looking at the tool name
-            if msg.name == "getCompanyNews":
-                # Skip adding tool_data for news queries since it's already formatted in the LLM response
+            if msg.name == "getStockRecommendation":
+                tool_message = msg.content
+                tool_type = "chart"
+                message_id = f"assistant-{uuid.uuid4()}"  # Generate unique ID
+                
+                # We don't need to update the graph state since it's ephemeral now
+            elif msg.name == "getCompanyNews":
                 tool_message = None
+                tool_type = "news"
             else:
                 tool_message = msg.content
+                tool_type = "data"
             break
 
-    # Return just the message for news queries, both message and tool data for others
+    # Return response with tool data, type and message ID
     return {
         "message": output["messages"][-1].content,
-        "tool_data": tool_message
+        "tool_data": tool_message,
+        "tool_type": tool_type,
+        "message_id": message_id  # Include message ID in response
     }


### PR DESCRIPTION
#7 Implemented a complete architecture change in how state is managed between the client and server:

**Server-side Improvements:**
- Implemented per-request graph instances in `server.py` using a graph_instances dictionary.
- Created unique thread IDs for each request to prevent state contamination
- Added a /reset endpoint to clear all graph state when needed
- Modified graph creation to use create_graph() function for fresh instances

**LLM Architecture Improvements:**
- Refactored LLM workflow to support dynamic graph creation with `create_graph()` function.
- Each graph now gets its own MemorySaver instance to prevent cross-contamination.
- Maintained backward compatibility while improving state isolation.

**Client Side Fix:**
- Added `current_chart_id` tracking to only show the latest requested chart
- Implemented complete chart state clearing between requests
- Added proper message ID handling from server responses
- Improved chart container management with unique keys

**TL;DR of fix:**
- The core issue was related to how LangGraph's state was persisting between requests. The solution creates fresh graph instances for each request and properly tracks which message should have an associated chart.